### PR TITLE
Datomic silently fails with an out of memory error

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -46,4 +46,5 @@
                                     :output-dir "resources/public/cljs"
                                     :optimizations :none}}]}
 
+  :jvm-opts ["-Xmx1g"]
   :main ^{:skip-aot true} session.main)


### PR DESCRIPTION
This should fix silent memory errors that occur when an attempt is made to create a new system database.

[Creating](https://github.com/kovasb/session/blob/a28d0f41e852e19c397f5d821eeacda5d08ddcd2/src/clj/session/datomic.clj#L143) the system database can cause an out of memory error from datomic. This error is suppressed by a the [try/catch](https://github.com/kovasb/session/blob/a28d0f41e852e19c397f5d821eeacda5d08ddcd2/src/clj/session/datomic.clj#L145) in the loop that waits for datomic to load.

> IllegalArgumentExceptionInfo :db.error/not-enough-memory (datomic.objectCacheMax + datomic.memoryIndexMax) exceeds 75% of JVM RAM datomic.error/arg (error.clj:55)

The solution seems to be [increase the max memory for the jvm](https://github.com/technomancy/leiningen/blob/master/sample.project.clj#L230).
